### PR TITLE
fixed logout() and renderUserGreeting()

### DIFF
--- a/frontend/scripts/auth.js
+++ b/frontend/scripts/auth.js
@@ -40,25 +40,24 @@ export async function checkRoleAccess(allowedRoles) {
     try {
         const userData = getUserFromToken();
         if (!userData || !allowedRoles.includes(userData.role)) {
-            const body = document.getElementsByTagName("body")[0];
-            body.innerHTML = "!! ACCESS DENIED !!";
-
-            await new Promise((resolve) => setTimeout(resolve, 1));
-
-            alert("No access to this page.");
-
-            window.location.href = "/frontend/html-pages/unauthorized.html"; // Fehlerseite
+            redirectToUnauthorizedPage();
         }
     } catch (error) {
         // TOKEN NOT FOUND ERROR
-        const body = document.getElementsByTagName("body")[0];
-        body.innerHTML = "!! ACCESS DENIED !!";
-        await new Promise((resolve) => setTimeout(resolve, 1));
         console.warn("Access denied because no token was found. Redirecting...");
-        alert("You must be logged in to view this page."); // Optional
-        window.location.href = "/frontend/html-pages/unauthorized.html"; // Hier leiten wir den nicht eingeloggten User weiter
+        redirectToUnauthorizedPage();
     }
+}
 
+export async function redirectToUnauthorizedPage() {
+    const body = document.getElementsByTagName("body")[0];
+    body.innerHTML = "!! ACCESS DENIED !!";
+
+    await new Promise((resolve) => setTimeout(resolve, 1)); // sonst ist content noch sichtbar
+
+    alert("No access to this page.");
+
+    window.location.href = "/frontend/html-pages/unauthorized.html"; // Fehlerseite
 }
 
 export function returnUserRole() {

--- a/frontend/scripts/auth.js
+++ b/frontend/scripts/auth.js
@@ -27,21 +27,38 @@ export function getUserFromToken() {
 // Logout
 export function logout() {
     localStorage.removeItem("token");
-    location.reload();
+
+    // reload site 
+    // location.reload();
+
+
+    alert("Your session has expired. You are being logged out.");
+    window.location.href = "/frontend/html-pages/unauthorized.html";
 }
 
 export async function checkRoleAccess(allowedRoles) {
-    const userData = getUserFromToken();
-    if (!userData || !allowedRoles.includes(userData.role)) {
+    try {
+        const userData = getUserFromToken();
+        if (!userData || !allowedRoles.includes(userData.role)) {
+            const body = document.getElementsByTagName("body")[0];
+            body.innerHTML = "!! ACCESS DENIED !!";
+
+            await new Promise((resolve) => setTimeout(resolve, 1));
+
+            alert("No access to this page.");
+
+            window.location.href = "/frontend/html-pages/unauthorized.html"; // Fehlerseite
+        }
+    } catch (error) {
+        // TOKEN NOT FOUND ERROR
         const body = document.getElementsByTagName("body")[0];
         body.innerHTML = "!! ACCESS DENIED !!";
-
         await new Promise((resolve) => setTimeout(resolve, 1));
-
-        alert("No access to this page.");
-
-        window.location.href = "/frontend/html-pages/unauthorized.html"; // Fehlerseite
+        console.warn("Access denied because no token was found. Redirecting...");
+        alert("You must be logged in to view this page."); // Optional
+        window.location.href = "/frontend/html-pages/unauthorized.html"; // Hier leiten wir den nicht eingeloggten User weiter
     }
+
 }
 
 export function returnUserRole() {

--- a/frontend/scripts/script.js
+++ b/frontend/scripts/script.js
@@ -5,6 +5,28 @@ import loadMeals from "./js-pages/meals.js";
 import * as Storage from "./storage.js";
 import * as Auth from "./auth.js";
 
+const valid = await Auth.checkSessionTokenValid();
+if (!valid) {
+    console.warn(
+        `[TokenCheck] ❌ Tokenprüfung fehlgeschlagen – Nutzer wird ausgeloggt11111111111`
+    );
+} else {
+    console.log(`[TokenCheck] ✅ Alles in Ordnung11111111111111`);
+}
+
+// AUTHENTICATION
+setInterval(async () => {
+    console.log(`[TokenCheck] 🔄 Starte regelmäßige Prüfung...`);
+    const valid = await Auth.checkSessionTokenValid();
+    if (!valid) {
+        console.warn(
+            `[TokenCheck] ❌ Tokenprüfung fehlgeschlagen – Nutzer wird ausgeloggt`
+        );
+    } else {
+        console.log(`[TokenCheck] ✅ Alles in Ordnung`);
+    }
+}, 5 * 60 * 1000); // alle 5 Minuten
+
 // SERVICE-WORKER REGISTRATION
 // The service worker registration code is currently disabled for debugging purposes.
 // Uncomment the following block to enable service worker functionality.
@@ -125,24 +147,3 @@ console.log("--------------DISHES WITH INGREDIENTS-------------");
 const dishesWithIngredients = await Storage.getDishesWithIngredients();
 console.log("HERE ARE THE FULL_DISHES:", dishesWithIngredients);
 
-const valid = await Auth.checkSessionTokenValid();
-if (!valid) {
-    console.warn(
-        `[TokenCheck] ❌ Tokenprüfung fehlgeschlagen – Nutzer wird ausgeloggt11111111111`
-    );
-} else {
-    console.log(`[TokenCheck] ✅ Alles in Ordnung11111111111111`);
-}
-
-// AUTHENTICATION
-setInterval(async () => {
-    console.log(`[TokenCheck] 🔄 Starte regelmäßige Prüfung...`);
-    const valid = await Auth.checkSessionTokenValid();
-    if (!valid) {
-        console.warn(
-            `[TokenCheck] ❌ Tokenprüfung fehlgeschlagen – Nutzer wird ausgeloggt`
-        );
-    } else {
-        console.log(`[TokenCheck] ✅ Alles in Ordnung`);
-    }
-}, 5 * 60 * 1000); // alle 5 Minuten


### PR DESCRIPTION
# Resolves #144 
# Changes:
fixed logout() and renderUserGreeting()

## what was the problem?
- Auth.getUserToken() is used in checkRoleAccess() since the last update and it threw an error that i had to handle in checkRoleAccess() => so now when there is no token left in LS checkRoleAccess() logs out the user manually by try-catch when user doesnt have a token at all.