### PR TITLE
fixed unit list bug (undefined)

### DIFF
--- a/frontend/scripts/js-pages/list.js
+++ b/frontend/scripts/js-pages/list.js
@@ -176,7 +176,7 @@ function saveNewItem() {
         name: itemName,
         category: category,
         amount: parseInt(amount, 10),
-        unit: unit
+        unit_of_measurement: unit
     };
 
     // Save the new item to storage (uncomment when ready)


### PR DESCRIPTION
# Resolves #215 
# Changes:
- fixed the bug when adding a new item, unit said "undefined"
- that was because i used the real name of the db but forgot to change the new created item unit name to the DBs name