### PR TITLE
show-cm-kg-years-in-settings

### DIFF
--- a/frontend/css/settings.css
+++ b/frontend/css/settings.css
@@ -401,7 +401,7 @@ eg8uzbeirzgbierzgbierbgierzbgoerbguzerbgiuerbgizebeuzgbiebgzerbgierzbgie */
 
 .input-wrapper input {
   width: 100%;
-  padding-right: 40px; /* Platz für Einheit */
+  padding-right: 40px; /* Space for unit label */
   box-sizing: border-box;
 }
 

--- a/frontend/css/settings.css
+++ b/frontend/css/settings.css
@@ -392,3 +392,25 @@ eg8uzbeirzgbierzgbierbgierzbgoerbguzerbgiuerbgizebeuzgbiebgzerbgierzbgie */
     display: none;
     /* Chrome, Safari and Opera */
 }
+
+.input-wrapper {
+  position: relative;
+  display: inline-block;
+  width: 100%;
+}
+
+.input-wrapper input {
+  width: 100%;
+  padding-right: 40px; /* Platz für Einheit */
+  box-sizing: border-box;
+}
+
+.unit-label {
+  position: absolute;
+  right: 10px;
+  top: 50%;
+  transform: translateY(-50%);
+  color: #777;
+  font-size: 0.9em;
+  pointer-events: none;
+}

--- a/frontend/html-pages/settings.html
+++ b/frontend/html-pages/settings.html
@@ -6,7 +6,7 @@
             <div id="arrow-back-st"> </div>
             <h1>Settings</h1>
             <div></div>
-<!-- ------------------ <button id="close-settings-btn" class="close-btn close-button-refer">
+            <!-- ------------------ <button id="close-settings-btn" class="close-btn close-button-refer">
                 <img src="/frontend/assets/icons/close-settings.svg" alt="Close">
             </button> ------------------- -->
         </div>
@@ -21,21 +21,35 @@
             <h1>Personal Data</h1>
             <div class="user-details-settings">
                 <div class="left-column-settings">
+
                     <div class="input-container">
                         <label class="subtext subtext-st" for="height-st">Height</label>
-                        <input type="text" id="height-st" placeholder="" name="height-st" value="" required>
+                        <div class="input-wrapper">
+                            <input type="number" id="height-st" name="height-st" required>
+                            <span class="unit-label">cm</span>
+                        </div>
                     </div>
+
                     <div class="input-container">
                         <label class="subtext subtext-st" for="weight-st">Weight</label>
-                        <input type="text" id="weight-st" placeholder="" name="weight-st" value="" required>
+                        <div class="input-wrapper">
+                            <input type="text" inputmode="decimal" id="weight-st" name="weight-st" required>
+                            <span class="unit-label">kg</span>
+                        </div>
                     </div>
+
                 </div>
 
                 <div class="right-column-settings">
+
                     <div class="input-container">
                         <label class="subtext subtext-st" for="age-st">Age</label>
-                        <input type="text" id="age-st" name="age-st" placeholder="" value="" required>
+                        <div class="input-wrapper">
+                            <input type="number" id="age-st" name="age-st" required>
+                            <span class="unit-label">years</span>
+                        </div>
                     </div>
+
                     <div class="input-container">
                         <label class="subtext subtext-st" for="sex-st">Sex</label>
                         <select id="sex-st" name="sex-st" required>
@@ -43,6 +57,7 @@
                             <option value="female">Female</option>
                         </select>
                     </div>
+
                 </div>
             </div> <!-- end-user-details-settings -->
         </div> <!-- end-settings-item-1 -->

--- a/frontend/scripts/js-pages/settings.js
+++ b/frontend/scripts/js-pages/settings.js
@@ -83,7 +83,7 @@ function updateUserData() {
 
     // Get values from inputs
     const heightCm = parseFloat(heightInput.value);
-    const weightKg = parseFloat(commaToDot(weightInput.value)).toFixed(1);
+    const weightKg = parseFloat(commaToDot(weightInput.value));
     const age = parseInt(ageInput.value, 10);
     const gender = sexSelect.value;
 

--- a/frontend/scripts/js-pages/settings.js
+++ b/frontend/scripts/js-pages/settings.js
@@ -145,8 +145,10 @@ function addEventListeners() {
     const weightInput = document.getElementById('weight-st');
 
     weightInput.addEventListener('keypress', (e) => {
-        const allowed = /[0-9.,]/;
-        if (!allowed.test(e.key)) {
+        const currentValue = weightInput.value;
+        const allowed = /^[0-9]*([.,][0-9]*)?$/;
+        const newValue = currentValue + e.key;
+        if (!allowed.test(newValue)) {
             e.preventDefault();
         }
     });

--- a/frontend/scripts/js-pages/settings.js
+++ b/frontend/scripts/js-pages/settings.js
@@ -26,6 +26,10 @@ export default async function loadSettings() {
 
 }
 
+function commaToDot(value) {
+    return value.toString().replace(',', '.');
+}
+
 async function loadUserData() {
     const { gender, age, weight_kg, weight_pounds, height_cm, height_feet_and_inches, activityLevel, goal } = await Storage.getUserDataFromDB();
 
@@ -35,8 +39,12 @@ async function loadUserData() {
     const sexSelect = document.getElementById('sex-st');
 
     heightInput.value = height_cm;
-    weightInput.value = weight_kg;
+    weightInput.value = commaToDot(weight_kg.toFixed(1));
     ageInput.value = age;
+
+    heightInput.placeholder = "cm";
+    weightInput.placeholder = "kg";
+    ageInput.placeholder = "years";
 
     if (gender) {
         sexSelect.value = gender.toLowerCase();
@@ -75,7 +83,7 @@ function updateUserData() {
 
     // Get values from inputs
     const heightCm = parseFloat(heightInput.value);
-    const weightKg = parseFloat(weightInput.value);
+    const weightKg = parseFloat(commaToDot(weightInput.value)).toFixed(1);
     const age = parseInt(ageInput.value, 10);
     const gender = sexSelect.value;
 
@@ -132,6 +140,16 @@ export function loadSavedTheme() {
 }
 
 function addEventListeners() {
+
+    // DONT ALLOW TO ENTER NON-NUMERIC VALUES IN HEIGHT AND WEIGHT INPUTS
+    const weightInput = document.getElementById('weight-st');
+
+    weightInput.addEventListener('keypress', (e) => {
+        const allowed = /[0-9.,]/;
+        if (!allowed.test(e.key)) {
+            e.preventDefault();
+        }
+    });
 
     const themeSelect = document.getElementById('theme-select')
     const savedTheme = localStorage.getItem('theme') || 'light';


### PR DESCRIPTION
# Resolves #207
# Changes:
show-cm-kg-years-in-settings

- added placeholder "cm", "kg", "years" when input field is empty
- added functionality to enter , or . both but always render . because is looks better
- always show "cm", "kg", "years" at the end of the input (egal ob man grade was in input schreibt oder nicht!)